### PR TITLE
feat: Ignore existing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const expectedOutput = [
   '</div>',
 ].join('\n')
 
-const options = {indent: 2} // 2 (spaces) is default
+const options = {indent: 2, newline: '\n'} // 2 spaces is default, newline defaults to require('os').EOL
 const output = prettifyXml(input, options) // options is optional
 
 assert(output === expectedOutput)

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,13 @@ const stringTimesN = (n, char) => Array(n + 1).join(char)
 function prettifyXml(xmlInput, options = {}) {
   const {
     indent: indentOption = 2,
+    newline: newlineOption = EOL,
   } = options
   const indentString = stringTimesN(indentOption, ' ')
 
   let formatted = ''
   const regex = /(>)(<)(\/*)/g
-  const xml = xmlInput.replace(regex, `$1${EOL}$2$3`)
+  const xml = xmlInput.replace(regex, `$1${newlineOption}$2$3`)
   let pad = 0
   xml.split(/\r?\n/).forEach((line) => {
     let indent = 0
@@ -30,7 +31,7 @@ function prettifyXml(xmlInput, options = {}) {
     }
 
     const padding = stringTimesN(pad, indentString)
-    formatted += padding + line + EOL // eslint-disable-line prefer-template
+    formatted += padding + line + newlineOption // eslint-disable-line prefer-template
     pad += indent
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ function prettifyXml(xmlInput, options = {}) {
   const regex = /(>)(<)(\/*)/g
   const xml = xmlInput.replace(regex, `$1${EOL}$2$3`)
   let pad = 0
-  xml.split(EOL).forEach((line) => {
+  xml.split(/\r?\n/).forEach((line) => {
     let indent = 0
     if (line.match(/.+<\/\w[^>]*>$/)) {
       indent = 0

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function prettifyXml(xmlInput, options = {}) {
   const xml = xmlInput.replace(regex, `$1${newlineOption}$2$3`)
   let pad = 0
   xml.split(/\r?\n/).forEach(l => {
-    const line = l.trim();
+    const line = l.trim()
 
     let indent = 0
     if (line.match(/.+<\/\w[^>]*>$/)) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -66,5 +66,12 @@ describe('prettifyXml', () => {
     const result = prettifyXml(input)
     assert(result === output)
   })
+
+  it('should accept non-unix newlines', () => {
+    const input = '<root>\r\n<test></test>\r\n</root>'
+    const output = '<root>\n  <test>\n  </test>\n</root>'
+    const result = prettifyXml(input)
+    assert(result === output)
+  })
 })
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -73,5 +73,12 @@ describe('prettifyXml', () => {
     const result = prettifyXml(input)
     assert(result === output)
   })
+
+  it('should use special newline if provided', () => {
+    const input = '<root><test></test></root>'
+    const output = '<root>\r\n  <test>\r\n  </test>\r\n</root>'
+    const result = prettifyXml(input, { newline: '\r\n' })
+    assert(result === output)
+  })
 })
 


### PR DESCRIPTION
Ignores existing whitespaces when reformatting.

**Example:**

Right now

```xml
<root>
.<child />
</root>
```

becomes

```xml
<root>
...<child />
</root>
```

when prettified.

After this PR, whitespaces in the original are ignored, so the result is:

```xml
<root>
..<child />
</root>
```
